### PR TITLE
Datastore 추가 및 access token으로 로그인 생략하기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,9 @@ dependencies {
 
     // datastore
     implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    // splash screen
+    implementation("androidx.core:core-splashscreen:1.0.1")
 }
 
 kapt {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,9 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.48")
     kapt("com.google.dagger:hilt-android-compiler:2.48")
     implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+
+    // datastore
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }
 
 kapt {

--- a/app/src/main/java/com/wafflestudio/snugo/MainActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/MainActivity.kt
@@ -3,7 +3,10 @@ package com.wafflestudio.snugo
 import android.app.ActivityManager
 import android.content.Context
 import android.os.Bundle
+import android.view.ViewGroup
+import android.view.ViewTreeObserver.OnPreDrawListener
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedContentTransitionScope
@@ -24,8 +27,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -39,6 +44,7 @@ import com.wafflestudio.snugo.features.arrivaldetail.ArrivalDetailScreen
 import com.wafflestudio.snugo.features.home.HomePageMode
 import com.wafflestudio.snugo.features.home.HomeScreen
 import com.wafflestudio.snugo.features.onboarding.SignInScreen
+import com.wafflestudio.snugo.features.onboarding.UserViewModel
 import com.wafflestudio.snugo.features.records.RecordsScreen
 import com.wafflestudio.snugo.features.settings.SettingsScreen
 import com.wafflestudio.snugo.location.LocationProvider
@@ -50,6 +56,8 @@ import com.wafflestudio.snugo.service.LocationService
 import com.wafflestudio.snugo.ui.theme.SnugoTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
@@ -58,9 +66,22 @@ class MainActivity : AppCompatActivity() {
     @Inject
     lateinit var locationProvider: LocationProvider
 
+    private val userViewModel: UserViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        installSplashScreen()
         getLocationPermissions()
+
+        var loadFinished = false
+        val startDestination = userViewModel.accessToken.filterNotNull().map {
+            loadFinished = true
+            if (it.isNotEmpty()) {
+                NavigationDestination.Main.route
+            } else {
+                NavigationDestination.Onboarding.route
+            }
+        }
 
         setContent {
             SnugoTheme {
@@ -79,6 +100,7 @@ class MainActivity : AppCompatActivity() {
                 var homePageMode by remember {
                     mutableStateOf(HomePageMode.NORMAL)
                 }
+                val startDestinationState by startDestination.collectAsState(initial = NavigationDestination.Onboarding.route)
 
                 CompositionLocalProvider(
                     LocalNavController provides navController,
@@ -88,7 +110,7 @@ class MainActivity : AppCompatActivity() {
                     ) {
                         NavHost(
                             navController = navController,
-                            startDestination = NavigationDestination.Onboarding.route,
+                            startDestination = startDestinationState,
                             modifier = Modifier.fillMaxSize(),
                         ) {
                             navigation(
@@ -145,24 +167,40 @@ class MainActivity : AppCompatActivity() {
                         }
                         BottomNavigation(
                             modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .align(Alignment.BottomCenter)
-                                    .offset {
-                                        IntOffset(
-                                            x = 0,
-                                            y =
-                                                animatedOffsetDp.dp
-                                                    .toPx()
-                                                    .roundToInt(),
-                                        )
-                                    },
+                            Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.BottomCenter)
+                                .offset {
+                                    IntOffset(
+                                        x = 0,
+                                        y =
+                                        animatedOffsetDp.dp
+                                            .toPx()
+                                            .roundToInt(),
+                                    )
+                                },
                             navController = navController,
                         )
                     }
                 }
             }
         }
+
+        val rootView = window.decorView
+            .findViewById<ViewGroup>(android.R.id.content)
+            .getChildAt(0) as ComposeView
+        rootView.viewTreeObserver.addOnPreDrawListener(
+            object : OnPreDrawListener {
+                override fun onPreDraw(): Boolean {
+                    return if (loadFinished) {
+                        rootView.viewTreeObserver.removeOnPreDrawListener(this)
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/snugo/MainActivity.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/MainActivity.kt
@@ -74,14 +74,15 @@ class MainActivity : AppCompatActivity() {
         getLocationPermissions()
 
         var loadFinished = false
-        val startDestination = userViewModel.accessToken.filterNotNull().map {
-            loadFinished = true
-            if (it.isNotEmpty()) {
-                NavigationDestination.Main.route
-            } else {
-                NavigationDestination.Onboarding.route
+        val startDestination =
+            userViewModel.accessToken.filterNotNull().map {
+                loadFinished = true
+                if (it.isNotEmpty()) {
+                    NavigationDestination.Main.route
+                } else {
+                    NavigationDestination.Onboarding.route
+                }
             }
-        }
 
         setContent {
             SnugoTheme {
@@ -167,18 +168,18 @@ class MainActivity : AppCompatActivity() {
                         }
                         BottomNavigation(
                             modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .align(Alignment.BottomCenter)
-                                .offset {
-                                    IntOffset(
-                                        x = 0,
-                                        y =
-                                        animatedOffsetDp.dp
-                                            .toPx()
-                                            .roundToInt(),
-                                    )
-                                },
+                                Modifier
+                                    .fillMaxWidth()
+                                    .align(Alignment.BottomCenter)
+                                    .offset {
+                                        IntOffset(
+                                            x = 0,
+                                            y =
+                                                animatedOffsetDp.dp
+                                                    .toPx()
+                                                    .roundToInt(),
+                                        )
+                                    },
                             navController = navController,
                         )
                     }
@@ -186,9 +187,10 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        val rootView = window.decorView
-            .findViewById<ViewGroup>(android.R.id.content)
-            .getChildAt(0) as ComposeView
+        val rootView =
+            window.decorView
+                .findViewById<ViewGroup>(android.R.id.content)
+                .getChildAt(0) as ComposeView
         rootView.viewTreeObserver.addOnPreDrawListener(
             object : OnPreDrawListener {
                 override fun onPreDraw(): Boolean {
@@ -199,7 +201,7 @@ class MainActivity : AppCompatActivity() {
                         false
                     }
                 }
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snugo/components/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/components/TopBar.kt
@@ -1,0 +1,36 @@
+package com.wafflestudio.snugo.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TopBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(MaterialTheme.colorScheme.background)
+            .padding(start = 16.dp, end = 16.dp, top = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        navigationIcon()
+        title()
+        Spacer(modifier = Modifier.weight(1f))
+        actions()
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snugo/components/TopBar.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/components/TopBar.kt
@@ -21,12 +21,13 @@ fun TopBar(
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .background(MaterialTheme.colorScheme.background)
-            .padding(start = 16.dp, end = 16.dp, top = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(start = 16.dp, end = 16.dp, top = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         navigationIcon()
         title()

--- a/app/src/main/java/com/wafflestudio/snugo/di/DataStoreModule.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/di/DataStoreModule.kt
@@ -1,0 +1,26 @@
+package com.wafflestudio.snugo.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "com.wafflestudio.snugo.preferences"
+)
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    @Provides
+    fun provideDataStore(
+        @ApplicationContext applicationContext: Context,
+    ): DataStore<Preferences> {
+        return applicationContext.dataStore
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snugo/di/DataStoreModule.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/di/DataStoreModule.kt
@@ -11,7 +11,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "com.wafflestudio.snugo.preferences"
+    name = "com.wafflestudio.snugo.preferences",
 )
 
 @Module

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/SignInScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/SignInScreen.kt
@@ -73,11 +73,12 @@ fun SignInScreen(
             TextField(
                 value = nickname,
                 onValueChange = { nickname = it },
+                label = { Text(text = "닉네임") },
                 keyboardOptions =
-                    KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                        imeAction = ImeAction.Next,
-                    ),
+                KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Next,
+                ),
                 keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
                 singleLine = true,
             )
@@ -90,7 +91,9 @@ fun SignInScreen(
                     value = departments[departmentIndex],
                     onValueChange = {},
                     readOnly = true,
+                    label = { Text(text = "단과대학") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isDepartmentMenuExpanded) },
+                    modifier = Modifier.menuAnchor()
                 )
                 ExposedDropdownMenu(
                     expanded = isDepartmentMenuExpanded,
@@ -119,9 +122,9 @@ fun SignInScreen(
                 }
             },
             modifier =
-                Modifier
-                    .padding(10.dp)
-                    .fillMaxWidth(),
+            Modifier
+                .padding(10.dp)
+                .fillMaxWidth(),
         ) {
             Text(
                 text = "로그인",

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/SignInScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/SignInScreen.kt
@@ -75,10 +75,10 @@ fun SignInScreen(
                 onValueChange = { nickname = it },
                 label = { Text(text = "닉네임") },
                 keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Text,
-                    imeAction = ImeAction.Next,
-                ),
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        imeAction = ImeAction.Next,
+                    ),
                 keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Down) }),
                 singleLine = true,
             )
@@ -93,7 +93,7 @@ fun SignInScreen(
                     readOnly = true,
                     label = { Text(text = "단과대학") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isDepartmentMenuExpanded) },
-                    modifier = Modifier.menuAnchor()
+                    modifier = Modifier.menuAnchor(),
                 )
                 ExposedDropdownMenu(
                     expanded = isDepartmentMenuExpanded,
@@ -122,9 +122,9 @@ fun SignInScreen(
                 }
             },
             modifier =
-            Modifier
-                .padding(10.dp)
-                .fillMaxWidth(),
+                Modifier
+                    .padding(10.dp)
+                    .fillMaxWidth(),
         ) {
             Text(
                 text = "로그인",

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
@@ -16,4 +16,6 @@ interface UserRepository {
         nickname: String,
         department: String,
     )
+
+    suspend fun signOut()
 }

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
@@ -1,6 +1,15 @@
 package com.wafflestudio.snugo.features.onboarding
 
+import kotlinx.coroutines.flow.Flow
+
 interface UserRepository {
+
+    val accessToken: Flow<String?>
+
+    val nickname: Flow<String?>
+
+    val department: Flow<String?>
+
     suspend fun getDepartments(): List<String>
 
     suspend fun signIn(

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepository.kt
@@ -3,7 +3,6 @@ package com.wafflestudio.snugo.features.onboarding
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
-
     val accessToken: Flow<String?>
 
     val nickname: Flow<String?>

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
@@ -10,59 +10,60 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UserRepositoryImpl @Inject constructor(
-    private val dataStore: DataStore<Preferences>
-) : UserRepository {
+class UserRepositoryImpl
+    @Inject
+    constructor(
+        private val dataStore: DataStore<Preferences>,
+    ) : UserRepository {
+        override val accessToken: Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] ?: "" }
 
-    override val accessToken: Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] ?: "" }
+        override val nickname: Flow<String?> = dataStore.data.map { it[NICKNAME] }
 
-    override val nickname: Flow<String?> = dataStore.data.map { it[NICKNAME] }
+        override val department: Flow<String?> = dataStore.data.map { it[DEPARTMENT] }
 
-    override val department: Flow<String?> = dataStore.data.map { it[DEPARTMENT] }
+        override suspend fun getDepartments(): List<String> {
+            return listOf(
+                "공과대학",
+                "자연과학대학",
+                "인문대학",
+                "사회과학대학",
+                "생활과학대학",
+                "농업생명과학대학",
+                "간호대학",
+                "경영대학",
+                "미술대학",
+                "사범대학",
+                "수의과대학",
+                "약학대학",
+                "음악대학",
+                "의과대학",
+                "자유전공학부",
+                "치의학대학원",
+            ).sorted()
+        }
 
-    override suspend fun getDepartments(): List<String> {
-        return listOf(
-            "공과대학",
-            "자연과학대학",
-            "인문대학",
-            "사회과학대학",
-            "생활과학대학",
-            "농업생명과학대학",
-            "간호대학",
-            "경영대학",
-            "미술대학",
-            "사범대학",
-            "수의과대학",
-            "약학대학",
-            "음악대학",
-            "의과대학",
-            "자유전공학부",
-            "치의학대학원",
-        ).sorted()
-    }
+        override suspend fun signIn(
+            nickname: String,
+            department: String,
+        ) {
+            dataStore.edit { preferences ->
+                preferences[ACCESS_TOKEN] = "testaccesstoken"
+                preferences[NICKNAME] = nickname
+                preferences[DEPARTMENT] = department
+            }
+        }
 
-    override suspend fun signIn(
-        nickname: String,
-        department: String,
-    ) {
-        dataStore.edit { preferences ->
-            preferences[ACCESS_TOKEN] = "testaccesstoken"
-            preferences[NICKNAME] = nickname
-            preferences[DEPARTMENT] = department
+        override suspend fun signOut() {
+            dataStore.edit { preferences ->
+                preferences.remove(ACCESS_TOKEN)
+                preferences.remove(NICKNAME)
+                preferences.remove(DEPARTMENT)
+            }
+        }
+
+        companion object {
+            val ACCESS_TOKEN = stringPreferencesKey("access_token")
+            val NICKNAME = stringPreferencesKey("nickname")
+            val DEPARTMENT = stringPreferencesKey("department")
         }
     }
-
-    override suspend fun signOut() {
-        dataStore.edit { preferences ->
-            preferences.remove(ACCESS_TOKEN)
-            preferences.remove(NICKNAME)
-            preferences.remove(DEPARTMENT)
-        }
-    }
-
-    companion object {
-        val ACCESS_TOKEN = stringPreferencesKey("access_token")
-        val NICKNAME = stringPreferencesKey("nickname")
-        val DEPARTMENT = stringPreferencesKey("department")
-    }
-}

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
@@ -14,7 +14,7 @@ class UserRepositoryImpl @Inject constructor(
     private val dataStore: DataStore<Preferences>
 ) : UserRepository {
 
-    override val accessToken: Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] }
+    override val accessToken: Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] ?: "" }
 
     override val nickname: Flow<String?> = dataStore.data.map { it[NICKNAME] }
 

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
@@ -52,6 +52,14 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun signOut() {
+        dataStore.edit { preferences ->
+            preferences.remove(ACCESS_TOKEN)
+            preferences.remove(NICKNAME)
+            preferences.remove(DEPARTMENT)
+        }
+    }
+
     companion object {
         val ACCESS_TOKEN = stringPreferencesKey("access_token")
         val NICKNAME = stringPreferencesKey("nickname")

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserRepositoryImpl.kt
@@ -1,36 +1,60 @@
 package com.wafflestudio.snugo.features.onboarding
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UserRepositoryImpl
-    @Inject
-    constructor() : UserRepository {
-        override suspend fun getDepartments(): List<String> {
-            return listOf(
-                "공과대학",
-                "자연과학대학",
-                "인문대학",
-                "사회과학대학",
-                "생활과학대학",
-                "농업생명과학대학",
-                "간호대학",
-                "경영대학",
-                "미술대학",
-                "사범대학",
-                "수의과대학",
-                "약학대학",
-                "음악대학",
-                "의과대학",
-                "자유전공학부",
-                "치의학대학원",
-            ).sorted()
-        }
+class UserRepositoryImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : UserRepository {
 
-        override suspend fun signIn(
-            nickname: String,
-            department: String,
-        ) {
+    override val accessToken: Flow<String?> = dataStore.data.map { it[ACCESS_TOKEN] }
+
+    override val nickname: Flow<String?> = dataStore.data.map { it[NICKNAME] }
+
+    override val department: Flow<String?> = dataStore.data.map { it[DEPARTMENT] }
+
+    override suspend fun getDepartments(): List<String> {
+        return listOf(
+            "공과대학",
+            "자연과학대학",
+            "인문대학",
+            "사회과학대학",
+            "생활과학대학",
+            "농업생명과학대학",
+            "간호대학",
+            "경영대학",
+            "미술대학",
+            "사범대학",
+            "수의과대학",
+            "약학대학",
+            "음악대학",
+            "의과대학",
+            "자유전공학부",
+            "치의학대학원",
+        ).sorted()
+    }
+
+    override suspend fun signIn(
+        nickname: String,
+        department: String,
+    ) {
+        dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN] = "testaccesstoken"
+            preferences[NICKNAME] = nickname
+            preferences[DEPARTMENT] = department
         }
     }
+
+    companion object {
+        val ACCESS_TOKEN = stringPreferencesKey("access_token")
+        val NICKNAME = stringPreferencesKey("nickname")
+        val DEPARTMENT = stringPreferencesKey("department")
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
@@ -11,45 +11,50 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel @Inject constructor(
-    private val userRepository: UserRepository,
-) : ViewModel() {
-    private val _departments = MutableStateFlow<List<String>>(emptyList())
-    val departments: StateFlow<List<String>> get() = _departments
+class UserViewModel
+    @Inject
+    constructor(
+        private val userRepository: UserRepository,
+    ) : ViewModel() {
+        private val _departments = MutableStateFlow<List<String>>(emptyList())
+        val departments: StateFlow<List<String>> get() = _departments
 
-    val accessToken: StateFlow<String?> = userRepository.accessToken
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+        val accessToken: StateFlow<String?> =
+            userRepository.accessToken
+                .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val nickname: StateFlow<String?> = userRepository.nickname
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+        val nickname: StateFlow<String?> =
+            userRepository.nickname
+                .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val userDepartment: StateFlow<String?> = userRepository.department
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+        val userDepartment: StateFlow<String?> =
+            userRepository.department
+                .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    init {
-        viewModelScope.launch {
-            fetchDepartments()
+        init {
+            viewModelScope.launch {
+                fetchDepartments()
+            }
+        }
+
+        suspend fun fetchDepartments() {
+            _departments.value =
+                userRepository.getDepartments().toMutableList().apply {
+                    add(0, "단과대학 선택")
+                }
+        }
+
+        suspend fun signIn(
+            nickname: String,
+            departmentIndex: Int,
+        ) {
+            userRepository.signIn(
+                nickname,
+                if (departmentIndex == 0) "" else _departments.value[departmentIndex],
+            )
+        }
+
+        suspend fun signOut() {
+            userRepository.signOut()
         }
     }
-
-    suspend fun fetchDepartments() {
-        _departments.value =
-            userRepository.getDepartments().toMutableList().apply {
-                add(0, "단과대학 선택")
-            }
-    }
-
-    suspend fun signIn(
-        nickname: String,
-        departmentIndex: Int,
-    ) {
-        userRepository.signIn(
-            nickname,
-            if (departmentIndex == 0) "" else _departments.value[departmentIndex],
-        )
-    }
-
-    suspend fun signOut() {
-        userRepository.signOut()
-    }
-}

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
@@ -48,4 +48,8 @@ class UserViewModel @Inject constructor(
             if (departmentIndex == 0) "" else _departments.value[departmentIndex],
         )
     }
+
+    suspend fun signOut() {
+        userRepository.signOut()
+    }
 }

--- a/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/onboarding/UserViewModel.kt
@@ -4,39 +4,48 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserViewModel
-    @Inject
-    constructor(
-        private val userRepository: UserRepository,
-    ) : ViewModel() {
-        private val _departments = MutableStateFlow<List<String>>(emptyList())
-        val departments: StateFlow<List<String>> get() = _departments
+class UserViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
+    private val _departments = MutableStateFlow<List<String>>(emptyList())
+    val departments: StateFlow<List<String>> get() = _departments
 
-        init {
-            viewModelScope.launch {
-                fetchDepartments()
-            }
-        }
+    val accessToken: StateFlow<String?> = userRepository.accessToken
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-        suspend fun fetchDepartments() {
-            _departments.value =
-                userRepository.getDepartments().toMutableList().apply {
-                    add(0, "단과대학 선택")
-                }
-        }
+    val nickname: StateFlow<String?> = userRepository.nickname
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-        suspend fun signIn(
-            nickname: String,
-            departmentIndex: Int,
-        ) {
-            userRepository.signIn(
-                nickname,
-                if (departmentIndex == 0) "" else _departments.value[departmentIndex],
-            )
+    val userDepartment: StateFlow<String?> = userRepository.department
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    init {
+        viewModelScope.launch {
+            fetchDepartments()
         }
     }
+
+    suspend fun fetchDepartments() {
+        _departments.value =
+            userRepository.getDepartments().toMutableList().apply {
+                add(0, "단과대학 선택")
+            }
+    }
+
+    suspend fun signIn(
+        nickname: String,
+        departmentIndex: Int,
+    ) {
+        userRepository.signIn(
+            nickname,
+            if (departmentIndex == 0) "" else _departments.value[departmentIndex],
+        )
+    }
+}

--- a/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
@@ -1,16 +1,25 @@
 package com.wafflestudio.snugo.features.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.wafflestudio.snugo.LocalNavController
 import com.wafflestudio.snugo.features.onboarding.UserViewModel
+import com.wafflestudio.snugo.navigateAsOrigin
+import com.wafflestudio.snugo.navigation.NavigationDestination
+import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(
@@ -20,18 +29,18 @@ fun SettingsScreen(
     val accessToken by userViewModel.accessToken.collectAsState()
     val nickname by userViewModel.nickname.collectAsState()
     val userDepartment by userViewModel.userDepartment.collectAsState()
+    val scope = rememberCoroutineScope()
+    val navController = LocalNavController.current
 
     Column(
         modifier =
         modifier
             .fillMaxSize(),
         verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = "settings screen",
-            modifier =
-            Modifier
-                .align(Alignment.CenterHorizontally),
         )
         Text(
             text = "access token: $accessToken"
@@ -41,6 +50,16 @@ fun SettingsScreen(
         )
         Text(
             text = "department: $userDepartment"
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(
+            text = "로그아웃",
+            modifier = Modifier.clickable {
+                scope.launch {
+                    userViewModel.signOut()
+                    navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
+                }
+            }
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
@@ -1,11 +1,20 @@
 package com.wafflestudio.snugo.features.settings
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -13,9 +22,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wafflestudio.snugo.LocalNavController
+import com.wafflestudio.snugo.R
+import com.wafflestudio.snugo.components.TopBar
 import com.wafflestudio.snugo.features.onboarding.UserViewModel
 import com.wafflestudio.snugo.navigateAsOrigin
 import com.wafflestudio.snugo.navigation.NavigationDestination
@@ -33,34 +47,69 @@ fun SettingsScreen(
     val navController = LocalNavController.current
 
     Column(
-        modifier =
-            modifier
-                .fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.fillMaxSize(),
     ) {
-        Text(
-            text = "settings screen",
-        )
-        Text(
-            text = "access token: $accessToken",
-        )
-        Text(
-            text = "nickname: $nickname",
-        )
-        Text(
-            text = "department: $userDepartment",
+        TopBar(
+            title = {
+                Text(
+                    text = "설정",
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontWeight = FontWeight.Bold
+                    ),
+                )
+            },
         )
         Spacer(modifier = Modifier.height(20.dp))
-        Text(
-            text = "로그아웃",
-            modifier =
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 0.5.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_person),
+                    contentDescription = "profile icon",
+                    modifier = Modifier
+                        .border(
+                            width = 0.5.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = CircleShape
+                        )
+                        .padding(5.dp)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Column(
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(
+                        text = nickname ?: "",
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                    Text(
+                        text = userDepartment ?: "",
+                        style = MaterialTheme.typography.titleSmall
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = "로그아웃",
+                modifier =
                 Modifier.clickable {
                     scope.launch {
                         userViewModel.signOut()
                         navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
                     }
                 },
-        )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snugo.features.settings
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -22,7 +21,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -53,37 +51,40 @@ fun SettingsScreen(
             title = {
                 Text(
                     text = "설정",
-                    style = MaterialTheme.typography.headlineSmall.copy(
-                        fontWeight = FontWeight.Bold
-                    ),
+                    style =
+                        MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                        ),
                 )
             },
         )
         Spacer(modifier = Modifier.height(20.dp))
         Column(
-            modifier = Modifier.padding(horizontal = 16.dp)
+            modifier = Modifier.padding(horizontal = 16.dp),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .border(
-                        width = 0.5.dp,
-                        color = MaterialTheme.colorScheme.outline,
-                        shape = RoundedCornerShape(10.dp)
-                    )
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 0.5.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                            shape = RoundedCornerShape(10.dp),
+                        )
+                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
                     painter = painterResource(R.drawable.ic_person),
                     contentDescription = "profile icon",
-                    modifier = Modifier
-                        .border(
-                            width = 0.5.dp,
-                            color = MaterialTheme.colorScheme.outline,
-                            shape = CircleShape
-                        )
-                        .padding(5.dp)
+                    modifier =
+                        Modifier
+                            .border(
+                                width = 0.5.dp,
+                                color = MaterialTheme.colorScheme.outline,
+                                shape = CircleShape,
+                            )
+                            .padding(5.dp),
                 )
                 Spacer(modifier = Modifier.width(10.dp))
                 Column(
@@ -95,7 +96,7 @@ fun SettingsScreen(
                     )
                     Text(
                         text = userDepartment ?: "",
-                        style = MaterialTheme.typography.titleSmall
+                        style = MaterialTheme.typography.titleSmall,
                     )
                 }
             }
@@ -103,12 +104,12 @@ fun SettingsScreen(
             Text(
                 text = "로그아웃",
                 modifier =
-                Modifier.clickable {
-                    scope.launch {
-                        userViewModel.signOut()
-                        navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
-                    }
-                },
+                    Modifier.clickable {
+                        scope.launch {
+                            userViewModel.signOut()
+                            navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
+                        }
+                    },
             )
         }
     }

--- a/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
@@ -5,22 +5,42 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wafflestudio.snugo.features.onboarding.UserViewModel
 
 @Composable
-fun SettingsScreen(modifier: Modifier = Modifier) {
+fun SettingsScreen(
+    modifier: Modifier = Modifier,
+    userViewModel: UserViewModel = hiltViewModel(),
+) {
+    val accessToken by userViewModel.accessToken.collectAsState()
+    val nickname by userViewModel.nickname.collectAsState()
+    val userDepartment by userViewModel.userDepartment.collectAsState()
+
     Column(
         modifier =
-            modifier
-                .fillMaxSize(),
+        modifier
+            .fillMaxSize(),
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
             text = "settings screen",
             modifier =
-                Modifier
-                    .align(Alignment.CenterHorizontally),
+            Modifier
+                .align(Alignment.CenterHorizontally),
+        )
+        Text(
+            text = "access token: $accessToken"
+        )
+        Text(
+            text = "nickname: $nickname"
+        )
+        Text(
+            text = "department: $userDepartment"
         )
     }
 }

--- a/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/wafflestudio/snugo/features/settings/SettingsScreen.kt
@@ -34,32 +34,33 @@ fun SettingsScreen(
 
     Column(
         modifier =
-        modifier
-            .fillMaxSize(),
+            modifier
+                .fillMaxSize(),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = "settings screen",
         )
         Text(
-            text = "access token: $accessToken"
+            text = "access token: $accessToken",
         )
         Text(
-            text = "nickname: $nickname"
+            text = "nickname: $nickname",
         )
         Text(
-            text = "department: $userDepartment"
+            text = "department: $userDepartment",
         )
         Spacer(modifier = Modifier.height(20.dp))
         Text(
             text = "로그아웃",
-            modifier = Modifier.clickable {
-                scope.launch {
-                    userViewModel.signOut()
-                    navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
-                }
-            }
+            modifier =
+                Modifier.clickable {
+                    scope.launch {
+                        userViewModel.signOut()
+                        navController.navigateAsOrigin(NavigationDestination.Onboarding.route)
+                    }
+                },
         )
     }
 }

--- a/app/src/main/res/drawable/ic_person.xml
+++ b/app/src/main/res/drawable/ic_person.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>


### PR DESCRIPTION
- Preference Datastore 추가
- 로그아웃 구현
- 앱 실행 시 access token이 있으면 startDestination을 Onboarding 말고 Main으로 설정
  - DataStore에서 access token을 가져올 때 flow로 가져오므로 값을 바로 알 수 없다. 그 시간 동안 splash screen을 띄웠다.
  - access token 값을 읽어 splash screen을 내렸을 때, startDestination도 동시에 바뀌면서 애니메이션이 보인다.... 해결 필요하지만 다른 중요한게 많으므로 일단 보류